### PR TITLE
Add support for function annotation(PEP 362)

### DIFF
--- a/example_black_scholes.py
+++ b/example_black_scholes.py
@@ -30,8 +30,7 @@ def price_BS(S, X, r, sigma, t):
     d2 = new_float(d1 - sigma*sqrt_t)
     c = new_float(S*cdf(d1)-X*exp(-r*t)*cdf(d2))
     return c
-        
+
 compiled = c99.compile(includes=['#include "math.h"'])
 for S in range(0,20):
-    print compiled.price_BS(S,10.0,0.2,0.5,90.0/250)
-
+    print(compiled.price_BS(S,10.0,0.2,0.5,90.0/250))


### PR DESCRIPTION
Python 3.0 support function signature (PEP 362), subsequently type hinting(PEP 484).
This PR enable such annotation, make the syntax more clean.
This also open up possibility to use type checking libraries.
